### PR TITLE
Keyloader: split LoadKey (sub function NewKey)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 go:
-  - 1.11.x
-  - 1.12.x
+  - 1.13.x
+  - 1.14.x
 
 # Only clone the most recent commit.
 git:
@@ -15,8 +15,7 @@ notifications:
 # build and immediately stop. It's sorta like having set -e enabled in bash.
 # Make sure golangci-lint is vendored.
 before_script:
-  - go get -v -u github.com/golangci/golangci-lint/cmd/golangci-lint
-  - go install github.com/golangci/golangci-lint/cmd/golangci-lint
+  - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.25.0
 
 # script always runs to completion (set +e). If we have linter issues AND a
 # failing test, we want to see both. Configure golangci-lint with a

--- a/symmecrypt_test.go
+++ b/symmecrypt_test.go
@@ -65,7 +65,7 @@ func ProviderTestKOSeal() (configstore.ItemList, error) {
 		Items: []configstore.Item{
 			configstore.NewItem(
 				keyloader.EncryptionKeyConfigName,
-				`{"key":"5fdb8af280b007a46553dfddb3f42bc10619dcabca8d4fdf5239b09445ab1a41","identifier":"test","sealed":false,"timestamp":2,"cipher":"aes-gcm"}`,
+				`{"key":"5fdb8af280b007a46553dfddb3f42bc10619dcabca8d4fdf5239b09445ab1a41","identifier":"test","sealed":false,"timestamp":10,"cipher":"aes-gcm"}`,
 				1,
 			),
 			configstore.NewItem(
@@ -400,7 +400,6 @@ func TestKeyloaderKO(t *testing.T) {
 
 	for testName, provider := range KOTests {
 		st := configstore.NewStore()
-
 		st.RegisterProvider("test", provider)
 
 		_, err := keyloader.LoadKeyFromStore("test", st)


### PR DESCRIPTION
NewKey directly accepts KeyConfig objects, without going through configstore.